### PR TITLE
Removed @Dependent annotation from Rest Client interface

### DIFF
--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -24,7 +24,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 // tag::annotations[]
-@Dependent
+
 @RegisterRestClient
 @RegisterProvider(UnknownUrlExceptionMapper.class)
 @Path("/properties")

--- a/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -24,7 +24,7 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 // tag::annotations[]
-@Dependent
+
 @RegisterRestClient
 @RegisterProvider(UnknownUrlExceptionMapper.class)
 @Path("/properties")


### PR DESCRIPTION
With the MP Rest Client 1.1 update, it is no longer necessary to add the @dependent annotation (or any scope annotation) to the Rest Client interface for CDI to recognize and process it because @RegisterRestClient is now a bean-defining annotation.