### PR TITLE
Removing Dependent annotation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -135,7 +135,7 @@ mvn liberty:stop-server
 Navigate to the `start` directory to begin.
 
 The MicroProfile Metrics API was added as a dependency to your `pom.xml` file. Look for the dependency with
-the `mpMetrics` artifact ID. Add this dependency to use MicroProfile Metrics API
+the `org.eclipse.microprofile.metric` artifact ID. Add this dependency to use MicroProfile Metrics API
 in your code to provide metrics from your microservices.
 
 Next, create a `src/main/liberty/config/server.xml` file:

--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -24,7 +24,6 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 // tag::annotations[]
-@Dependent
 @RegisterRestClient
 @RegisterProvider(UnknownUrlExceptionMapper.class)
 @Path("/properties")

--- a/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -24,7 +24,6 @@ import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 // tag::annotations[]
-@Dependent
 @RegisterRestClient
 @RegisterProvider(UnknownUrlExceptionMapper.class)
 @Path("/properties")


### PR DESCRIPTION
With the MP Rest Client 1.1 update, it is no longer necessary to add the @dependent annotation (or any scope annotation) to the Rest Client interface for CDI to recognize and process it because @RegisterRestClient is now a bean-defining annotation.