### PR TITLE
Mp metrics2x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: java
 before_script:
 - unset _JAVA_OPTIONS
 - cd finish
+- chmod +x ../scripts/travisTest.sh
 script:
-- mvn clean install -q
+- ../scripts/travisTest.sh
 - serverName=$(target/liberty/wlp/bin/server list | cut -d '.' -f2| tr -d '\n');
 - build=$(grep "Open Liberty" target/liberty/wlp/usr/servers/"$serverName"/logs/console.log
   | cut -d' ' -f5 | cut -d')' -f1 ); release=$( echo "$build" | cut -d'/' -f1); number=$(

--- a/README.adoc
+++ b/README.adoc
@@ -123,9 +123,9 @@ See the following sample output for the `@Gauge` and `@Counted` metrics:
 
 [role="no_copy"]
 ----
-# TYPE base:jvm_uptime_seconds gauge
-# HELP base:jvm_uptime_seconds Displays the start time of the Java virtual machine in milliseconds. This attribute displays the approximate time when the Java virtual machine started.
-base:jvm_uptime_seconds 39.025
+# TYPE base_jvm_uptime_seconds gauge
+# HELP base_jvm_uptime_seconds Displays the start time of the Java virtual machine in milliseconds. This attribute displays the approximate time when the Java virtual machine started.
+base_jvm_uptime_seconds 30.342000000000002
 ----
 [role="no_copy"]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -63,14 +63,13 @@ include::{common-includes}/gitclone.adoc[]
 The `finish` directory contains the finished implementation for the application. You can try it out
 before you build your own.
 
-To try the application, navigate to the `finish` directory and run the following command:
+To try out the application, first go to the `finish` directory and run the 
+following Maven goal to build the application and deploy it to Open Liberty:
 
 [role=command]
 -----------
-mvn install liberty:start-server
+mvn liberty:run
 -----------
-
-Maven builds the application and runs it inside Open Liberty.
 
 Point your browser to the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL to access the `inventory`
 service. Because you just started the application, the inventory is currently empty. Then, access the
@@ -108,9 +107,9 @@ application_inventoryProcessingTime_seconds{method="list",quantile="0.5"} 2.2185
 ----
 [role="no_copy"]
 ----
-# TYPE application_inventorySizeGuage gauge
-# HELP application_inventorySizeGuage Number of systems in the inventory
-application_inventorySizeGuage 1
+# TYPE application_inventorySizeGauge gauge
+# HELP application_inventorySizeGauge Number of systems in the inventory
+application_inventorySizeGauge 1
 ----
 [role="no_copy"]
 ----
@@ -153,11 +152,12 @@ vendor_threadpool_size{pool="Default_Executor"} 32
 vendor_servlet_request_total{servlet="microprofile_metrics_io_openliberty_guides_inventory_InventoryApplication"} 1
 ----
 
-When you're done with the application, stop the Open Liberty server with the following command:
+After you are done checking out the application, stop the Open Liberty server by pressing `CTRL+C` in the shell session where you ran the server. 
+Alternatively, you can run the `liberty:stop` goal from the `finish` directory in another shell session:
 
 [role=command]
 ----
-mvn liberty:stop-server
+mvn liberty:stop
 ----
 
 // =================================================================================================
@@ -180,13 +180,21 @@ include::finish/src/main/liberty/config/server.xml[]
 
 Navigate to the `start` directory to begin.
 
-The MicroProfile Metrics API was added as a dependency to your [hotspot file=0]`pom.xml` file. This is the dependency with
-the [hotspot=mpMetrics file=0]`mpMetrics` artifact ID. This dependency was added to use the MicroProfile Metrics API
+Start Open Liberty in development mode, which starts the Open Liberty server and listens for file changes:
+
+[role=command]
+----
+mvn liberty:dev
+----
+
+The MicroProfile Metrics API is included in the MicroProfile dependency specified by your [hotspot file=0]`pom.xml` file. 
+Look for the dependency with the [hotspot=microprofile file=0]`microprofile` artifact ID.
+This dependency provides a library that allows you to use the MicroProfile Metrics API
 in your code to provide metrics from your microservices.
 
 [role="code_command hotspot file=1", subs="quotes"]
 ----
-#Create the server configuration file.#
+#Replace the server configuration file.#
 `src/main/liberty/config/server.xml`
 ----
 
@@ -203,7 +211,7 @@ The [hotspot=quickStartSecurity file=1]`quickStartSecurity` and [hotspot=keyStor
 
 [role="code_command hotspot", subs="quotes"]
 ----
-#Create the `InventoryManager` class.#
+#Replace the `InventoryManager` class.#
 `src/main/java/io/openliberty/guides/inventory/InventoryManager.java`
 ----
 
@@ -269,8 +277,9 @@ Visit the https://openliberty.io/docs/ref/general/#metrics-catalog.html[Metrics 
 // Building and running the application
 // =================================================================================================
 
-[role=command]
-include::{common-includes}/mvnbuild.adoc[]
+== Building and running the application
+
+The Open Liberty server was started in development mode at the beginning of the guide and all the changes were automatically picked up.
 
 Point your browser to the https://localhost:9443/metrics[https://localhost:9443/metrics^] URL to review the all available metrics
 that have been enabled through MicroProfile Metrics. Log in with `admin` as your username and
@@ -284,18 +293,16 @@ https://localhost:9443/metrics/application[https://localhost:9443/metrics/applic
 You can see the system metrics in the https://localhost:9443/metrics/base[^] URL.
 You can also see the vendor metrics in the https://localhost:9443/metrics/vendor[^] URL.
 
-[role=command]
-include::{common-includes}/mvncompile.adoc[]
 
 // =================================================================================================
 // Testing the metrics
 // =================================================================================================
 
 == Testing the metrics
-MetricsTest.java
-[source, java, linenums, role='code_column']
+MetricsIT.java
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/src/test/java/it/io/openliberty/guides/metrics/MetricsTest.java[tags=MetricsTest]
+include::finish/src/test/java/it/io/openliberty/guides/metrics/MetricsIT.java[]
 ----
 
 InventoryManager.java
@@ -310,69 +317,75 @@ environment for you to write tests.
 
 [role="code_command hotspot file=0", subs="quotes"]
 ----
-#Create the `MetricsTest` class.#
-`src/test/java/it/io/openliberty/guides/metrics/MetricsTest.java`
+#Create the `MetricsIT` class.#
+`src/test/java/it/io/openliberty/guides/metrics/MetricsIT.java`
 ----
 
-* The [hotspot=55-65 file=0]`testPropertiesRequestTimeMetric()` test case validates the [hotspot=timedForGet file=1]`@Timed` metric. It sends a request to the
+* The [hotspot=testPropertiesRequestTimeMetric file=0]`testPropertiesRequestTimeMetric()` test case validates the [hotspot=timedForGet file=1]`@Timed` metric. It sends a request to the
 `\http://localhost:9080/inventory/systems/localhost` URL to access the `inventory` service, which adds
 the `localhost` host to the inventory. Next, the test case makes a connection to the
 `\https://localhost:9443/metrics/application` URL to retrieve application metrics as plain text.
 Then, it asserts whether the time that is needed to retrieve
 the system properties for localhost is less than 4 seconds.
 
-* The [hotspot=67-76 file=0]`testInventoryAccessCountMetric()` test case validates the [hotspot=countedForList file=1]`@Counted` metric. The test case sends a request to the
+* The [hotspot=testInventoryAccessCountMetric file=0]`testInventoryAccessCountMetric()` test case validates the [hotspot=countedForList file=1]`@Counted` metric. The test case sends a request to the
 `\http://localhost:9080/inventory/systems` URL to retrieve the whole inventory, and then it asserts
-that this endpoint is accessed only once.
+that this endpoint is accessed at least once.
 
-* The [hotspot=78-87 file=0]`testInventorySizeGaugeMetric()` test case validates the [hotspot=gaugeForGetTotal file=1]`@Gauge` metric. The test case first ensures
+* The [hotspot=testInventorySizeGaugeMetric file=0]`testInventorySizeGaugeMetric()` test case validates the [hotspot=gaugeForGetTotal file=1]`@Gauge` metric. The test case first ensures
 that the localhost is in the inventory. It then looks for the [hotspot=gaugeForGetTotal file=1]`@Gauge` metric and asserts
-that the inventory size is equal to 1.
+that the inventory size is greater or equal to 1.
 
-The [hotspot=30-35 file=0]`oneTimeSetup()` method retrieves the port number for the server and builds a base URL string
-to set up the tests. Apply the [hotspot=29 file=0]`@BeforeClass` annotation to this method to execute it before any of
+The [hotspot=oneTimeSetup file=0]`oneTimeSetup()` method retrieves the port number for the server and builds a base URL string
+to set up the tests. Apply the [hotspot=BeforeAll file=0]`@BeforeAll` annotation to this method to execute it before any of
 the test cases.
 
-The [hotspot=38-41]`setup()` method creates a JAX-RS client that makes HTTP requests to the `inventory` service.
-Register this client with a [hotspot=40 file=0]`JsrJsonpProvider` JSON-P provider to process JSON resources. The
-[hotspot=44-46]`teardown()` method destroys this client instance. Apply the [hotspot=37 file=0]`@Before` annotation so that a method
-executes before a test case, and apply the [hotspot=43 file=0]`@After` annotation so that a method executes after a test
+The [hotspot=setup file=0]`setup()` method creates a JAX-RS client that makes HTTP requests to the `inventory` service.
+Register this client with a [hotspot=JsrJsonpProvider file=0]`JsrJsonpProvider` JSON-P provider to process JSON resources. The
+[hotspot=teardown file=0]`teardown()` method destroys this client instance. Apply the [hotspot=BeforeEach file=0]`@BeforeEach` annotation so that a method
+executes before a test case, and apply the [hotspot=AfterEach file=0]`@AfterEach` annotation so that a method executes after a test
 case. Apply these annotations to methods that are generally used to perform any setup and teardown tasks
 before and after a test.
 
-To execute the test cases in a particular order, put them in a [hotspot=49-53 file=0]`testSuite()` method.
-Label the method with the [hotspot=48]`@Test` annotation, which automatically executes when your test class runs.
+To execute the test cases in a particular order, put them in a [hotspot=testSuite file=0]`testSuite()` method.
+Label the method with the [hotspot=Test file=0]`@Test` annotation, which automatically executes when your test class runs.
 
-In addition, a few endpoint tests `src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointTest.java`
-and `src/test/java/it/io/openliberty/guides/system/SystemEndpointTest.java` are provided for you to
+In addition, a few endpoint tests `src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java`
+and `src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java` are provided for you to
 test the basic functionality of the `inventory` and `system` services. If a test failure occurs, then you might have
 introduced a bug into the code.
 
 // =================================================================================================
 // Running the tests
 // =================================================================================================
-[role=command]
-include::{common-includes}/mvnverify.adoc[]
+
+=== Running the tests
+
+Since you started Open Liberty in development mode at the start of the guide, press the `enter/return` key to run the tests. 
+You will see the following output:
 
 [source, role="no_copy"]
 ----
 -------------------------------------------------------
  T E S T S
 -------------------------------------------------------
-Running it.io.openliberty.guides.system.SystemEndpointTest
-Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.4 sec - in it.io.openliberty.guides.system.SystemEndpointTest
-Running it.io.openliberty.guides.metrics.MetricsTest
-Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.697 sec - in it.io.openliberty.guides.metrics.MetricsTest
-Running it.io.openliberty.guides.inventory.InventoryEndpointTest
-Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.264 sec - in it.io.openliberty.guides.inventory.InventoryEndpointTest
+Running it.io.openliberty.guides.system.SystemEndpointIT
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.4 sec - in it.io.openliberty.guides.system.SystemEndpointIT
+Running it.io.openliberty.guides.metrics.MetricsIT
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.697 sec - in it.io.openliberty.guides.metrics.MetricsIT
+Running it.io.openliberty.guides.inventory.InventoryEndpointIT
+Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.264 sec - in it.io.openliberty.guides.inventory.InventoryIT
 
 Results :
 
 Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
 ----
 
-To see whether the tests detect a failure, go to the [hotspot file=0]`MetricsTest.java` file and change any of the assertions
-in the test methods. Rerun the Maven build. A test failure occurs.
+To see whether the tests detect a failure, go to the [hotspot file=0]`MetricsIT.java` file and change any of the assertions
+in the test methods. Rerun the tests to see a test failure occur.
+
+When you are done checking out the service, exit development mode by typing `q` in the shell session 
+where you ran the server and then pressing the `enter/return` key.
 
 // =================================================================================================
 // Great work! You're done!

--- a/README.adoc
+++ b/README.adoc
@@ -87,21 +87,22 @@ See the following sample outputs for the `@Timed`, `@Gauge`, and `@Counted` metr
 
 [role="no_copy"]
 ----
-# TYPE application:inventory_properties_request_time_rate_per_second gauge
-application:inventory_properties_request_time_rate_per_second 0.012564862395324394
-# HELP application:inventory_properties_request_time_seconds Time needed to get the properties of a system from the given hostname
+# TYPE application_inventoryPropertiesRequestTime_rate_per_second gauge
+application_inventoryPropertiesRequestTime_rate_per_second 0.13199736470323709
+# HELP application_inventoryPropertiesRequestTime_seconds Time needed to get the properties of a system from the given hostname
+application_inventoryPropertiesRequestTime_seconds_count 1
 ----
 [role="no_copy"]
 ----
-# TYPE application:inventory_size_guage gauge
-# HELP application:inventory_size_guage Number of systems in the inventory
-application:inventory_size_guage 1
+# TYPE application_inventorySizeGuage gauge
+# HELP application_inventorySizeGuage Number of systems in the inventory
+application_inventorySizeGuage 1
 ----
 [role="no_copy"]
 ----
-# TYPE application:inventory_access_count counter
-# HELP application:inventory_access_count Number of times the list of systems method is requested
-application:inventory_access_count 1
+# TYPE application_inventoryAccessCount_total counter
+# HELP application_inventoryAccessCount_total Number of times the list of systems method is requested
+application_inventoryAccessCount_total 1
 ----
 
 To see only the system metrics, point your browser to https://localhost:9443/metrics/base[https://localhost:9443/metrics/base^].
@@ -116,9 +117,26 @@ base:jvm_uptime_seconds 39.025
 ----
 [role="no_copy"]
 ----
-# TYPE base:classloader_current_loaded_class_count counter
-# HELP base:classloader_current_loaded_class_count Displays the number of classes that are currently loaded in the Java virtual machine.
-base:classloader_current_loaded_class_count 9144
+# TYPE base_classloader_loadedClasses_count gauge
+# HELP base_classloader_loadedClasses_count Displays the number of classes that are currently loaded in the Java virtual machine.
+base_classloader_loadedClasses_count 11231
+----
+
+To see only the vendor metrics, point your browser to https://localhost:9443/metrics/vendor[https://localhost:9443/metrics/vendor^].
+
+See the following sample output for the `@Gauge` and `@Counted` metrics:
+
+[role="no_copy"]
+----
+# TYPE vendor_threadpool_size gauge
+# HELP vendor_threadpool_size The size of the thread pool.
+vendor_threadpool_size{pool="Default_Executor"} 32
+----
+[role="no_copy"]
+----
+# TYPE vendor_servlet_request_total counter
+# HELP vendor_servlet_request_total The number of visits to this servlet since the start of the server.
+vendor_servlet_request_total{servlet="microprofile_metrics_io_openliberty_guides_inventory_InventoryApplication"} 1
 ----
 
 When you're done with the application, stop the Open Liberty server with the following command:
@@ -137,7 +155,7 @@ mvn liberty:stop-server
 pom.xml
 [source, xml, linenums, role='code_column']
 ----
-include::finish/pom.xml[tags=!comment]
+include::finish/pom.xml[]
 ----
 
 server.xml
@@ -194,7 +212,7 @@ metadata fields:
 |===
 
 Apply the [hotspot=42-44]`@Counted` annotation to the [hotspot=45-47]`list()` method to count how many times the
-http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL is accessed. 
+http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL is accessed monotonically, which is counting up sequentially.
 
 Apply the [hotspot=49-52]`@Gauge` annotation to the [hotspot=53-55]`getTotal()` method to track the number of systems that are stored in
 the inventory. Note that when the value of the gauge is retrieved, the underlying [hotspot=53-55]`getTotal()` method
@@ -207,6 +225,24 @@ is called to return the size of the inventory. Note the additional metadata fiel
 Additional information about these annotations, relevant metadata fields, and more are available at
 the https://microprofile.io/project/eclipse/microprofile-metrics[MicroProfile website^].
 
+
+== Enabling vendor metrics for the micorservices
+
+server.xml
+[source, xml, linenums, role='code_column']
+----
+include::finish/src/main/liberty/config/server.xml[tags=server]
+----
+
+MicroProfile Metrics API implementors can provide vendor metrics in the same forms as the base and application outputs.
+Liberty as a vendor supplies server component metrics when both the
+[hotspot=mpMetrics]`mpMetrics` and [hotspot=monitor]`monitor` features are enabled in the [hotspot]`server.xml` configuration file.
+
+You can see the vendor only metrics in the https://localhost:9443/metrics/vendor[https://localhost:9443/metrics/vendor^] URL.
+You see metrics from the runtime components, such as Web Application, ThreadPool and Session Management.
+Note that these metrics are specific to Liberty application server. Different vendor may provide other metrics.
+Visit https://www.ibm.com/support/knowledgecenter/en/SSD28V_liberty/com.ibm.websphere.wlp.core.doc/ae/rwlp_monitor_metrics_rest_api.html[Liberty vendor metrics^] for more information.
+
 // =================================================================================================
 // Building and running the application
 // =================================================================================================
@@ -216,7 +252,7 @@ include::{common-includes}/mvnbuild.adoc[]
 
 Point your browser to the https://localhost:9443/metrics[https://localhost:9443/metrics^] URL to review the all available metrics
 that have been enabled through MicroProfile Metrics. Log in with `admin` as your username and
-`adminpwd` as your password. You see only the system metrics because the server just started,
+`adminpwd` as your password. You see only the system and vendor metrics because the server just started,
 and the `inventory` service has not been accessed.
 
 Next, point your browser to the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL. Reload the
@@ -319,7 +355,7 @@ in the test methods. Rerun the Maven build. A test failure occurs.
 
 == Great work! You're done!
 
-You learned how to enable system and application metrics for microservices by using MicroProfile Metrics
+You learned how to enable system, application and vendor metrics for microservices by using MicroProfile Metrics
 and wrote tests to validate them in Open Liberty.
 
 include::{common-includes}/attribution.adoc[subs="attributes"]

--- a/README.adoc
+++ b/README.adoc
@@ -231,7 +231,7 @@ Both the [hotspot=get]`get()` and [hotspot=list]`list()` methods are annotated w
 - The [hotspot=tagForGet]`method=get` tag identifies the [hotspot=nameForGet]`inventoryProcessingTime` metric that measures the time to get the system properties from calling the `system` service.
 - The [hotspot=tagForList]`method=list` tag identifies the [hotspot=nameForList]`inventoryProcessingTime` metric that measures the time for the `inventory` service to list all of the system properties in the inventory.
 
-The tags can then be queried in a metrics monitoring tool for the inventory processing time.
+The tags allow the metrics to be queried together or separately given the functionality of the monitoring tool of your choice. The `inventoryProcessingTime` metrics for example could be queried to display an aggregate time of both tagged metrics or individual times.
 
 Apply the [hotspot=countedForList]`@Counted` annotation to the [hotspot=list]`list()` method to count how many times the
 `\http://localhost:9080/inventory/systems` URL is accessed monotonically, which is counting up sequentially.

--- a/README.adoc
+++ b/README.adoc
@@ -91,7 +91,7 @@ See the following sample outputs for the `@Timed`, `@Gauge`, and `@Counted` metr
 application_inventoryProcessingTime_rate_per_second{method="get"} 0.0019189661542898407
 ...
 # TYPE application_inventoryProcessingTime_seconds summary
-# HELP application_inventoryProcessingTime_seconds Time needed to get the properties of a system
+# HELP application_inventoryProcessingTime_seconds Time needed to process the inventory
 application_inventoryProcessingTime_seconds_count{method="get"} 1
 application_inventoryProcessingTime_seconds{method="get",quantile="0.5"} 0.127965469
 ...
@@ -99,7 +99,7 @@ application_inventoryProcessingTime_seconds{method="get",quantile="0.5"} 0.12796
 application_inventoryProcessingTime_rate_per_second{method="list"} 0.0038379320982686884
 ...
 # TYPE application_inventoryProcessingTime_seconds summary
-# HELP application_inventoryProcessingTime_seconds Time needed to create an inventory list of systems
+# HELP application_inventoryProcessingTime_seconds Time needed to process the inventory
 application_inventoryProcessingTime_seconds_count{method="list"} 2
 application_inventoryProcessingTime_seconds{method="list",quantile="0.5"} 2.2185000000000002E-5
 ...

--- a/README.adoc
+++ b/README.adoc
@@ -87,10 +87,14 @@ See the following sample outputs for the `@Timed`, `@Gauge`, and `@Counted` metr
 
 [role="no_copy"]
 ----
-# TYPE application_inventoryPropertiesRequestTime_rate_per_second gauge
-application_inventoryPropertiesRequestTime_rate_per_second 0.13199736470323709
-# HELP application_inventoryPropertiesRequestTime_seconds Time needed to get the properties of a system from the given hostname
-application_inventoryPropertiesRequestTime_seconds_count 1
+# TYPE application_inventoryProcessingTime_rate_per_second gauge
+application_inventoryProcessingTime_rate_per_second{method="get"} 0.037187510967201284
+# HELP application_inventoryProcessingTime_seconds Time needed to process the inventory
+application_inventoryProcessingTime_seconds_count{method="get"} 1
+# TYPE application_inventoryProcessingTime_rate_per_second gauge
+application_inventoryProcessingTime_rate_per_second{method="list"} 0.0743762996056714
+# HELP application_inventoryProcessingTime_seconds Time needed to process the inventory
+application_inventoryProcessingTime_seconds_count{method="list"} 2
 ----
 [role="no_copy"]
 ----
@@ -161,13 +165,13 @@ include::finish/pom.xml[]
 server.xml
 [source, xml, linenums, role='code_column']
 ----
-include::finish/src/main/liberty/config/server.xml[tags=server]
+include::finish/src/main/liberty/config/server.xml[]
 ----
 
 Navigate to the `start` directory to begin.
 
 The MicroProfile Metrics API was added as a dependency to your [hotspot file=0]`pom.xml` file. This is the dependency with
-the [hotspot=63 file=0]`mpMetrics` artifact ID. This dependency was added to use the MicroProfile Metrics API
+the [hotspot=mpMetrics file=0]`mpMetrics` artifact ID. This dependency was added to use the MicroProfile Metrics API
 in your code to provide metrics from your microservices.
 
 [role="code_command hotspot file=1", subs="quotes"]
@@ -176,12 +180,10 @@ in your code to provide metrics from your microservices.
 `src/main/liberty/config/server.xml`
 ----
 
-The [hotspot=7 file=1]`mpMetrics` feature enables MicroProfile Metrics support in Open Liberty. Note that this
+The [hotspot=mpMetrics file=1]`mpMetrics` feature enables MicroProfile Metrics support in Open Liberty. Note that this
 feature requires SSL and the configuration has been provided for you.
 
-The [hotspot=12 file=1]`quickStartSecurity` and [hotspot=13 file=1]`keyStore` configuration elements provide basic security to secure the
-server. When you visit the `/metrics` endpoint, use the credentials defined in the server
-configuration to log in to view the data.
+The [hotspot=quickStartSecurity file=1]`quickStartSecurity` and [hotspot=keyStore file=1]`keyStore` configuration elements provide basic security to secure the server. When you visit the `/metrics` endpoint, use the credentials defined in the server configuration to log in to view the data.
 
 // =================================================================================================
 // Adding the annotations
@@ -196,30 +198,39 @@ configuration to log in to view the data.
 ----
 
 InventoryManager.java
-[source, java, linenums, role='code_column']
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java[tags=InventoryManager]
+include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java[]
 ----
 
-Apply the [hotspot=23-26]`@Timed` annotation to the [hotspot=27-29]`get()` method to track how frequently the method is
-invoked and also how long it takes for the invocation to complete. This annotation has these
-metadata fields:
+Apply the [hotspot=timedForGet]`@Timed` annotation to the [hotspot=get]`get()` method,
+and apply the [hotspot=timedForList]`@Timed` annotation to the [hotspot=list]`list()` method.
+
+This annotation has these metadata fields:
 
 |===
-|[hotspot=23]`name` | Optional. Use this field to name of the metric.
-|[hotspot=24]`absolute` | Optional. Use this field to determine whether the metric name is the exact name that is specified in the [hotspot=23]`name` field or that is specified with the package prefix.
-|[hotspot=25-26]`description` | Optional. Use this field to describe the purpose of the metric.
+|[hotspot=nameForGet hotspot=nameForList]`name` | Optional. Use this field to name the metric.
+|[hotspot=tagForGet hotspot=tagForList]`tags` | Optional. Use this field to add tags to the metric with the same [hotspot=nameForGet hotspot=nameForList]`name`.
+|[hotspot=absoluteForGet hotspot=absoluteForList]`absolute` | Optional. Use this field to determine whether the metric name is the exact name that is specified in the [hotspot=nameForGet hotspot=nameForList]`name` field or that is specified with the package prefix.
+|[hotspot=desForGet hotspot=desForList]`description` | Optional. Use this field to describe the purpose of the metric.
 |===
 
-Apply the [hotspot=42-44]`@Counted` annotation to the [hotspot=45-47]`list()` method to count how many times the
-http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL is accessed monotonically, which is counting up sequentially.
+Both the [hotspot=get]`get()` and [hotspot=list]`list()` methods are annotated with the `@Timed` metric and have the same [hotspot=nameForGet hotspot=nameForList]`inventoryProcessingTime` name. The `@Timed` annotation tracks how frequently and how long it takes for the method invocation to complete. The [hotspot=tagForGet]`method=get` and [hotspot=tagForList]`method=list` tags add a dimension to the collected metric data for the inventory processing time in getting the system properties.
 
-Apply the [hotspot=49-52]`@Gauge` annotation to the [hotspot=53-55]`getTotal()` method to track the number of systems that are stored in
-the inventory. Note that when the value of the gauge is retrieved, the underlying [hotspot=53-55]`getTotal()` method
+- The `method=get` processing time tag indicates the time to get the system properties from calling the `system` service.
+- The `method=list` processing time tag indicates the time for the `inventory` service to list all of the system properties in the inventory.
+
+The tags can then be queried with either the processing time for the [hotspot=get]`get()` method or the [hotspot=list]`list()` method or both.
+
+Apply the [hotspot=countedForList]`@Counted` annotation to the [hotspot=list]`list()` method to count how many times the
+\http://localhost:9080/inventory/systems URL is accessed monotonically, which is counting up sequentially.
+
+Apply the [hotspot=gaugeForGetTotal]`@Gauge` annotation to the [hotspot=getTotal]`getTotal()` method to track the number of systems that are stored in
+the inventory. Note that when the value of the gauge is retrieved, the underlying [hotspot=getTotal]`getTotal()` method
 is called to return the size of the inventory. Note the additional metadata field:
 
 |===
-| [hotspot=49]`unit` | Set the unit of the metric. If it is [hotspot=49]`MetricUnits.NONE`, the metric name is used as is without appending the unit name, and no scaling is applied.
+| [hotspot=unitForGetTotal]`unit` | Set the unit of the metric. If it is [hotspot=unitForGetTotal]`MetricUnits.NONE`, the metric name is used as is without appending the unit name, and no scaling is applied.
 |===
 
 Additional information about these annotations, relevant metadata fields, and more are available at
@@ -231,14 +242,14 @@ the https://microprofile.io/project/eclipse/microprofile-metrics[MicroProfile we
 server.xml
 [source, xml, linenums, role='code_column']
 ----
-include::finish/src/main/liberty/config/server.xml[tags=server]
+include::finish/src/main/liberty/config/server.xml[]
 ----
 
 MicroProfile Metrics API implementors can provide vendor metrics in the same forms as the base and application outputs.
 Liberty as a vendor supplies server component metrics when both the
 [hotspot=mpMetrics]`mpMetrics` and [hotspot=monitor]`monitor` features are enabled in the [hotspot]`server.xml` configuration file.
 
-You can see the vendor only metrics in the https://localhost:9443/metrics/vendor[https://localhost:9443/metrics/vendor^] URL.
+You can see the vendor only metrics in the `metrics/vendor` endpoint.
 You see metrics from the runtime components, such as Web Application, ThreadPool and Session Management.
 Note that these metrics are specific to Liberty application server. Different vendor may provide other metrics.
 Visit https://www.ibm.com/support/knowledgecenter/en/SSD28V_liberty/com.ibm.websphere.wlp.core.doc/ae/rwlp_monitor_metrics_rest_api.html[Liberty vendor metrics^] for more information.
@@ -258,6 +269,9 @@ and the `inventory` service has not been accessed.
 Next, point your browser to the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL. Reload the
 https://localhost:9443/metrics[https://localhost:9443/metrics^] URL, or access only the application metrics at the
 https://localhost:9443/metrics/application[https://localhost:9443/metrics/application^] URL.
+
+You can see the system metrics in the https://localhost:9443/metrics/base[^] URL.
+You can also see the vendor metrics in the https://localhost:9443/metrics/vendor[^] URL.
 
 [role=command]
 include::{common-includes}/mvncompile.adoc[]

--- a/README.adoc
+++ b/README.adoc
@@ -16,7 +16,7 @@
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['rest-intro', 'microprofile-health', 'cdi-intro']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
-page-seo-title: Providing metrics from a microservice with MicroProfile Metrics
+:page-seo-title: Providing metrics from a microservice with MicroProfile Metrics
 :page-seo-description: A tutorial and an example on how to provide metrics from a microservice using MicroProfile Metrics.
 :source-highlighter: prettify
 :guide-author: Open Liberty
@@ -228,10 +228,10 @@ This annotation has these metadata fields:
 The `@Timed` annotation tracks how frequently and how long it takes for the method invocation to complete.
 Both the [hotspot=get]`get()` and [hotspot=list]`list()` methods are annotated with the `@Timed` metric and have the same [hotspot=nameForGet hotspot=nameForList]`inventoryProcessingTime` name. The [hotspot=tagForGet]`method=get` and [hotspot=tagForList]`method=list` tags add a dimension to uniquely identify the collected metric data for the inventory processing time in getting the system properties.
 
-- The `method=get` tagged processing time indicates the time to get the system properties from calling the `system` service.
-- The `method=list` tagged processing time indicates the time for the `inventory` service to list all of the system properties in the inventory.
+- The [hotspot=tagForGet]`method=get` tag identifies the [hotspot=nameForGet]`inventoryProcessingTime` metric that measures the time to get the system properties from calling the `system` service.
+- The [hotspot=tagForList]`method=list` tag identifies the [hotspot=nameForList]`inventoryProcessingTime` metric that measures the time for the `inventory` service to list all of the system properties in the inventory.
 
-The tags can then be queried with either the processing time for the [hotspot=get]`get()` method or the [hotspot=list]`list()` method or both.
+The tags can then be queried in a metrics monitoring tool for the inventory processing time.
 
 Apply the [hotspot=countedForList]`@Counted` annotation to the [hotspot=list]`list()` method to count how many times the
 `\http://localhost:9080/inventory/systems` URL is accessed monotonically, which is counting up sequentially.

--- a/README.adoc
+++ b/README.adoc
@@ -231,7 +231,7 @@ Both the [hotspot=get]`get()` and [hotspot=list]`list()` methods are annotated w
 The tags can then be queried with either the processing time for the [hotspot=get]`get()` method or the [hotspot=list]`list()` method or both.
 
 Apply the [hotspot=countedForList]`@Counted` annotation to the [hotspot=list]`list()` method to count how many times the
-\http://localhost:9080/inventory/systems URL is accessed monotonically, which is counting up sequentially.
+`\http://localhost:9080/inventory/systems` URL is accessed monotonically, which is counting up sequentially.
 
 Apply the [hotspot=gaugeForGetTotal]`@Gauge` annotation to the [hotspot=getTotal]`getTotal()` method to track the number of systems that are stored in
 the inventory. Note that when the value of the gauge is retrieved, the underlying [hotspot=getTotal]`getTotal()` method
@@ -296,9 +296,9 @@ include::finish/src/test/java/it/io/openliberty/guides/metrics/MetricsTest.java[
 ----
 
 InventoryManager.java
-[source, java, linenums, role='code_column']
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
-include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java[tags=InventoryManager]
+include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java[]
 ----
 
 You can test your application manually, but automated tests ensure code quality because they trigger a
@@ -311,19 +311,19 @@ environment for you to write tests.
 `src/test/java/it/io/openliberty/guides/metrics/MetricsTest.java`
 ----
 
-* The [hotspot=55-65 file=0]`testPropertiesRequestTimeMetric()` test case validates the [hotspot=23-26 file=1]`@Timed` metric. It sends a request to the
+* The [hotspot=55-65 file=0]`testPropertiesRequestTimeMetric()` test case validates the [hotspot=timedForGet file=1]`@Timed` metric. It sends a request to the
 `\http://localhost:9080/inventory/systems/localhost` URL to access the `inventory` service, which adds
 the `localhost` host to the inventory. Next, the test case makes a connection to the
 `\https://localhost:9443/metrics/application` URL to retrieve application metrics as plain text.
 Then, it asserts whether the time that is needed to retrieve
 the system properties for localhost is less than 4 seconds.
 
-* The [hotspot=67-76 file=0]`testInventoryAccessCountMetric()` test case validates the [hotspot=42-44 file=1]`@Counted` metric. The test case sends a request to the
+* The [hotspot=67-76 file=0]`testInventoryAccessCountMetric()` test case validates the [hotspot=countedForList file=1]`@Counted` metric. The test case sends a request to the
 `\http://localhost:9080/inventory/systems` URL to retrieve the whole inventory, and then it asserts
 that this endpoint is accessed only once.
 
-* The [hotspot=78-87 file=0]`testInventorySizeGaugeMetric()` test case validates the [hotspot=49-52 file=1]`@Gauge` metric. The test case first ensures
-that the localhost is in the inventory. It then looks for the [hotspot=49-52 file=1]`@Gauge` metric and asserts
+* The [hotspot=78-87 file=0]`testInventorySizeGaugeMetric()` test case validates the [hotspot=gaugeForGetTotal file=1]`@Gauge` metric. The test case first ensures
+that the localhost is in the inventory. It then looks for the [hotspot=gaugeForGetTotal file=1]`@Gauge` metric and asserts
 that the inventory size is equal to 1.
 
 The [hotspot=30-35 file=0]`oneTimeSetup()` method retrieves the port number for the server and builds a base URL string

--- a/README.adoc
+++ b/README.adoc
@@ -88,13 +88,21 @@ See the following sample outputs for the `@Timed`, `@Gauge`, and `@Counted` metr
 [role="no_copy"]
 ----
 # TYPE application_inventoryProcessingTime_rate_per_second gauge
-application_inventoryProcessingTime_rate_per_second{method="get"} 0.037187510967201284
-# HELP application_inventoryProcessingTime_seconds Time needed to process the inventory
+application_inventoryProcessingTime_rate_per_second{method="get"} 0.0019189661542898407
+...
+# TYPE application_inventoryProcessingTime_seconds summary
+# HELP application_inventoryProcessingTime_seconds Time needed to get the properties of a system
 application_inventoryProcessingTime_seconds_count{method="get"} 1
+application_inventoryProcessingTime_seconds{method="get",quantile="0.5"} 0.127965469
+...
 # TYPE application_inventoryProcessingTime_rate_per_second gauge
-application_inventoryProcessingTime_rate_per_second{method="list"} 0.0743762996056714
-# HELP application_inventoryProcessingTime_seconds Time needed to process the inventory
+application_inventoryProcessingTime_rate_per_second{method="list"} 0.0038379320982686884
+...
+# TYPE application_inventoryProcessingTime_seconds summary
+# HELP application_inventoryProcessingTime_seconds Time needed to create an inventory list of systems
 application_inventoryProcessingTime_seconds_count{method="list"} 2
+application_inventoryProcessingTime_seconds{method="list",quantile="0.5"} 2.2185000000000002E-5
+...
 ----
 [role="no_copy"]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -242,7 +242,7 @@ is called to return the size of the inventory. Note the additional metadata fiel
 |===
 
 Additional information about these annotations, relevant metadata fields, and more are available at
-the https://microprofile.io/project/eclipse/microprofile-metrics[MicroProfile website^].
+the https://openliberty.io/docs/ref/microprofile/3.0/#package=org/eclipse/microprofile/metrics/annotation/package-frame.html&class=org/eclipse/microprofile/metrics/annotation/package-summary.html[MicroProfile Metrics Annotation Javadoc^].
 
 
 == Enabling vendor metrics for the micorservices

--- a/README.adoc
+++ b/README.adoc
@@ -16,6 +16,8 @@
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['rest-intro', 'microprofile-health', 'cdi-intro']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
+page-seo-title: Providing metrics from a microservice with MicroProfile Metrics
+:page-seo-description: A tutorial and an example on how to provide metrics from a microservice using MicroProfile Metrics.
 :source-highlighter: prettify
 :guide-author: Open Liberty
 = Providing metrics from a microservice
@@ -223,10 +225,11 @@ This annotation has these metadata fields:
 |[hotspot=desForGet hotspot=desForList]`description` | Optional. Use this field to describe the purpose of the metric.
 |===
 
-Both the [hotspot=get]`get()` and [hotspot=list]`list()` methods are annotated with the `@Timed` metric and have the same [hotspot=nameForGet hotspot=nameForList]`inventoryProcessingTime` name. The `@Timed` annotation tracks how frequently and how long it takes for the method invocation to complete. The [hotspot=tagForGet]`method=get` and [hotspot=tagForList]`method=list` tags add a dimension to the collected metric data for the inventory processing time in getting the system properties.
+The `@Timed` annotation tracks how frequently and how long it takes for the method invocation to complete.
+Both the [hotspot=get]`get()` and [hotspot=list]`list()` methods are annotated with the `@Timed` metric and have the same [hotspot=nameForGet hotspot=nameForList]`inventoryProcessingTime` name. The [hotspot=tagForGet]`method=get` and [hotspot=tagForList]`method=list` tags add a dimension to uniquely identify the collected metric data for the inventory processing time in getting the system properties.
 
-- The `method=get` processing time tag indicates the time to get the system properties from calling the `system` service.
-- The `method=list` processing time tag indicates the time for the `inventory` service to list all of the system properties in the inventory.
+- The `method=get` tagged processing time indicates the time to get the system properties from calling the `system` service.
+- The `method=list` tagged processing time indicates the time for the `inventory` service to list all of the system properties in the inventory.
 
 The tags can then be queried with either the processing time for the [hotspot=get]`get()` method or the [hotspot=list]`list()` method or both.
 

--- a/README.adoc
+++ b/README.adoc
@@ -121,7 +121,7 @@ application_inventoryAccessCount_total 1
 
 To see only the system metrics, point your browser to https://localhost:9443/metrics/base[https://localhost:9443/metrics/base^].
 
-See the following sample output for the `@Gauge` and `@Counted` metrics:
+See the following sample output:
 
 [role="no_copy"]
 ----
@@ -138,7 +138,7 @@ base_classloader_loadedClasses_count 11231
 
 To see only the vendor metrics, point your browser to https://localhost:9443/metrics/vendor[https://localhost:9443/metrics/vendor^].
 
-See the following sample output for the `@Gauge` and `@Counted` metrics:
+See the following sample output:
 
 [role="no_copy"]
 ----
@@ -263,7 +263,7 @@ Liberty as a vendor supplies server component metrics when both the
 You can see the vendor only metrics in the `metrics/vendor` endpoint.
 You see metrics from the runtime components, such as Web Application, ThreadPool and Session Management.
 Note that these metrics are specific to Liberty application server. Different vendor may provide other metrics.
-Visit https://www.ibm.com/support/knowledgecenter/en/SSD28V_liberty/com.ibm.websphere.wlp.core.doc/ae/rwlp_monitor_metrics_rest_api.html[Liberty vendor metrics^] for more information.
+Visit the https://openliberty.io/docs/ref/general/#metrics-catalog.html[Metrics reference list^] for more information.
 
 // =================================================================================================
 // Building and running the application

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -3,14 +3,8 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-      <groupId>net.wasdev.wlp.maven.parent</groupId>
-      <artifactId>liberty-maven-app-parent</artifactId>
-      <version>RELEASE</version>
-  </parent>
-
   <groupId>io.openliberty.guides</groupId>
-  <artifactId>microprofile-metrics</artifactId>
+  <artifactId>guide-microprofile-metrics</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>war</packaging>
 
@@ -19,66 +13,32 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <app.name>LibertyProject</app.name>
-    <!-- tag::ports[] -->
-    <testServerHttpPort>9080</testServerHttpPort>
-    <testServerHttpsPort>9443</testServerHttpsPort>
-    <!-- end::ports[] -->
-    <package.file>${project.build.directory}/${app.name}.zip</package.file>
-    <packaging.type>usr</packaging.type>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
+    <!-- Plugin versions -->
+    <version.maven-failsafe-plugin>2.22.2</version.maven-failsafe-plugin>
+    <version.maven-war-plugin>3.2.2</version.maven-war-plugin>
+    <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
+    <!-- Liberty configuration -->
+    <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+    <liberty.var.default.https.port>9443</liberty.var.default.https.port>
   </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.openliberty.features</groupId>
-                <artifactId>features-bom</artifactId>
-                <version>RELEASE</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
   <dependencies>
-    <!-- Open Liberty features -->
+    <!-- Provided dependencies -->
     <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>jaxrs-2.1</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
-    </dependency>
-    <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>jsonp-1.1</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
-    </dependency>
-    <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>cdi-2.0</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
-    </dependency>
-    <!-- tag::mpMetrics[] -->
-    <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>mpMetrics-2.0</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
-    </dependency>
-    <!-- end::mpMetrics[] -->
-    <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>mpRestClient-1.3</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
+      <groupId>org.eclipse.microprofile</groupId>
+      <!-- tag::microprofile[] -->
+      <artifactId>microprofile</artifactId>
+      <!-- end::microprofile[] -->
+      <version>3.0</version>
+      <type>pom</type>
+      <scope>provided</scope>
     </dependency>
     <!-- For tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -124,119 +84,38 @@
         <version>2.3.2</version>
         <scope>test</scope>
     </dependency>
-    <dependency>
-        <groupId>javax.activation</groupId>
-        <artifactId>activation</artifactId>
-        <version>1.1.1</version>
-        <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
+    <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.2.2</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-          <packagingExcludes>pom.xml</packagingExcludes>
-        </configuration>
+        <version>${version.maven-war-plugin}</version>
       </plugin>
       <!-- Plugin to run unit tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
-        <executions>
-          <execution>
-            <phase>test</phase>
-            <id>default-test</id>
-            <configuration>
-              <excludes>
-                <exclude>**/it/**</exclude>
-              </excludes>
-              <reportsDirectory>${project.build.directory}/test-reports/unit</reportsDirectory>
-            </configuration>
-          </execution>
-        </executions>
+        <version>${version.maven-surefire-plugin}</version>
       </plugin>
       <!-- Enable liberty-maven plugin -->
       <plugin>
-        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+        <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <configuration>
-          <assemblyArtifact>
-            <groupId>io.openliberty</groupId>
-            <artifactId>openliberty-runtime</artifactId>
-            <version>RELEASE</version>
-            <type>zip</type>
-          </assemblyArtifact>
-          <configFile>src/main/liberty/config/server.xml</configFile>
-          <packageFile>${package.file}</packageFile>
-          <include>${packaging.type}</include>
-          <bootstrapProperties>
-            <default.http.port>${testServerHttpPort}</default.http.port>
-            <default.https.port>${testServerHttpsPort}</default.https.port>
-          </bootstrapProperties>
-        </configuration>
-        <executions>
-          <execution>
-            <id>install-apps</id>
-            <configuration>
-              <looseApplication>true</looseApplication>
-              <stripVersion>true</stripVersion>
-              <installAppPackages>project</installAppPackages>
-            </configuration>
-          </execution>
-          <execution>
-            <id>package-server</id>
-            <phase>package</phase>
-            <goals>
-              <goal>package-server</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>target/wlp-package</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <!-- Plugin to run functional tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
-        <executions>
-          <execution>
-            <phase>integration-test</phase>
-            <id>integration-test</id>
-            <goals>
-              <goal>integration-test</goal>
-            </goals>
-            <configuration>
-              <runOrder>reversealphabetical</runOrder>
-              <includes>
-                <include>**/it/**/*.java</include>
-              </includes>
-              <!-- tag::system-props[] -->
-              <systemPropertyVariables>
-                <liberty.test.port>${testServerHttpPort}</liberty.test.port>
-                <liberty.https.port>${testServerHttpsPort}</liberty.https.port>
-                <javax.net.ssl.trustStore>${project.build.directory}/liberty/wlp/usr/servers/defaultServer/resources/security/key.jks</javax.net.ssl.trustStore>
-              </systemPropertyVariables>
-              <!-- end::system-props[] -->
-            </configuration>
-          </execution>
-          <execution>
-            <id>verify-results</id>
-            <goals>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
+        <version>${version.maven-failsafe-plugin}</version>
         <configuration>
-          <summaryFile>${project.build.directory}/test-reports/it/failsafe-summary.xml</summaryFile>
-          <reportsDirectory>${project.build.directory}/test-reports/it</reportsDirectory>
+          <systemPropertyVariables>
+            <http.port>${liberty.var.default.http.port}</http.port>
+            <https.port>${liberty.var.default.https.port}</https.port>
+            <javax.net.ssl.trustStore>${project.build.directory}/liberty/wlp/usr/servers/defaultServer/resources/security/key.jks</javax.net.ssl.trustStore>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -60,14 +60,14 @@
         <type>esa</type>
         <scope>provided</scope>
     </dependency>
-    <!-- tag::metrics[] -->
+    <!-- tag::mpMetrics[] -->
     <dependency>
         <groupId>io.openliberty.features</groupId>
         <artifactId>mpMetrics-2.0</artifactId>
         <type>esa</type>
         <scope>provided</scope>
     </dependency>
-    <!-- end::metrics[] -->
+    <!-- end::mpMetrics[] -->
     <dependency>
         <groupId>io.openliberty.features</groupId>
         <artifactId>mpRestClient-1.3</artifactId>

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -18,14 +18,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
 import io.openliberty.guides.inventory.model.InventoryList;
 import io.openliberty.guides.inventory.model.SystemData;
-
-import javax.enterprise.context.ApplicationScoped;
-import org.eclipse.microprofile.metrics.annotation.Counted;
-import org.eclipse.microprofile.metrics.annotation.Timed;
-import org.eclipse.microprofile.metrics.annotation.Gauge;
-import org.eclipse.microprofile.metrics.MetricUnits;
 
 // tag::ApplicationScoped[]
 @ApplicationScoped
@@ -35,10 +36,13 @@ public class InventoryManager {
   private List<SystemData> systems = Collections.synchronizedList(new ArrayList<>());
   private InventoryUtils invUtils = new InventoryUtils();
 
-  @Timed(name = "inventoryPropertiesRequestTime", 
-    absolute = true,
-    description = "Time needed to get the properties of" +
-      "a system from the given hostname")
+    /*
+     * @Timed(name = "inventoryPropertiesRequestTime", absolute = true, description
+     * = "Time needed to get the properties of " +
+     * "a system from the given hostname")
+     */
+  @Timed(tags = {"type=system"}, name = "inventoryPropertiesRequestTime", absolute = true,
+    description = "Time needed to get the system properties")
   public Properties get(String hostname) {
     return invUtils.getProperties(hostname);
   }
@@ -53,17 +57,16 @@ public class InventoryManager {
       systems.add(host);
   }
 
-
-  @Counted(name = "inventoryAccessCount", 
-    absolute = true, 
-    description = "Number of times the list of systems method is requested")
+  @Counted(name = "inventoryAccessCount", absolute = true, description =
+    "Number of times the list of systems method is requested")
+  @Timed(tags = {"type=inventory"}, name = "inventoryPropertiesRequestTime", absolute = true,
+    description = "Time needed to get the system properties")
   public InventoryList list() {
     return new InventoryList(systems);
   }
 
-  @Gauge(unit = MetricUnits.NONE, 
-    name = "inventorySizeGuage", 
-    absolute = true,
+
+  @Gauge(unit = MetricUnits.NONE, name = "inventorySizeGuage", absolute = true,
     description = "Number of systems in the inventory")
   public int getTotal() {
     return systems.size();

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -36,16 +36,25 @@ public class InventoryManager {
   private List<SystemData> systems = Collections.synchronizedList(new ArrayList<>());
   private InventoryUtils invUtils = new InventoryUtils();
 
-    /*
-     * @Timed(name = "inventoryPropertiesRequestTime", absolute = true, description
-     * = "Time needed to get the properties of " +
-     * "a system from the given hostname")
-     */
-  @Timed(tags = {"type=system"}, name = "inventoryPropertiesRequestTime", absolute = true,
-    description = "Time needed to get the system properties")
+  // tag::timedForGet[]
+  // tag::nameForGet[]
+  @Timed(name = "inventoryProcessingTime",
+  // end::nameForGet[]
+         // tag::tagForGet[]
+         tags = {"method=get"},
+         // end::tagForGet[]
+         // tag::absoluteForGet[]
+         absolute = true,
+         // end::absoluteForGet[]
+         // tag::desForGet[]
+         description = "Time needed to process the inventory")
+         // end::desForGet[]
+  // end::timedForGet[]
+  // tag::get[]
   public Properties get(String hostname) {
     return invUtils.getProperties(hostname);
   }
+  // end::get[]
 
   public void add(String hostname, Properties systemProps) {
     Properties props = new Properties();
@@ -57,20 +66,43 @@ public class InventoryManager {
       systems.add(host);
   }
 
-  @Counted(name = "inventoryAccessCount", absolute = true, description =
-    "Number of times the list of systems method is requested")
-  @Timed(tags = {"type=inventory"}, name = "inventoryPropertiesRequestTime", absolute = true,
-    description = "Time needed to get the system properties")
+  // tag::timedForList[]
+  // tag::nameForList[]
+  @Timed(name = "inventoryProcessingTime",
+  // end::nameForList[]
+         // tag::tagForList[]
+         tags = {"method=list"},
+         // end::tagForList[]
+         // tag::absoluteForList[]
+         absolute = true,
+         // end::absoluteForList[]
+         // tag::desForList[]
+         description = "Time needed to process the inventory")
+         // end::desForList[]
+  // end::timedForList[]
+  // tag::countedForList[]
+  @Counted(name = "inventoryAccessCount",
+           absolute = true,
+           description = "Number of times the list of systems method is requested")
+  // end::countedForList[]
+  // tag::list[]
   public InventoryList list() {
     return new InventoryList(systems);
   }
+  // end::list[]
 
-
-  @Gauge(unit = MetricUnits.NONE, name = "inventorySizeGuage", absolute = true,
-    description = "Number of systems in the inventory")
+  // tag::gaugeForGetTotal[]
+  // tag::unitForGetTotal[]
+  @Gauge(unit = MetricUnits.NONE,
+  // end::unitForGetTotal[]
+         name = "inventorySizeGuage",
+         absolute = true,
+         description = "Number of systems in the inventory")
+  // end::gaugeForGetTotal[]
+  // tag::getTotal[]
   public int getTotal() {
     return systems.size();
   }
-
+  // end::getTotal[]
 }
 // end::InventoryManager[]

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -95,7 +95,7 @@ public class InventoryManager {
   // tag::unitForGetTotal[]
   @Gauge(unit = MetricUnits.NONE,
   // end::unitForGetTotal[]
-         name = "inventorySizeGuage",
+         name = "inventorySizeGauge",
          absolute = true,
          description = "Number of systems in the inventory")
   // end::gaugeForGetTotal[]

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -47,7 +47,7 @@ public class InventoryManager {
          absolute = true,
          // end::absoluteForGet[]
          // tag::desForGet[]
-         description = "Time needed to process the inventory")
+         description = "Time needed to get the properties of a system")
          // end::desForGet[]
   // end::timedForGet[]
   // tag::get[]
@@ -77,7 +77,7 @@ public class InventoryManager {
          absolute = true,
          // end::absoluteForList[]
          // tag::desForList[]
-         description = "Time needed to process the inventory")
+         description = "Time needed to create an inventory list of systems")
          // end::desForList[]
   // end::timedForList[]
   // tag::countedForList[]

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -47,7 +47,7 @@ public class InventoryManager {
          absolute = true,
          // end::absoluteForGet[]
          // tag::desForGet[]
-         description = "Time needed to get the properties of a system")
+         description = "Time needed to process the inventory")
          // end::desForGet[]
   // end::timedForGet[]
   // tag::get[]
@@ -77,7 +77,7 @@ public class InventoryManager {
          absolute = true,
          // end::absoluteForList[]
          // tag::desForList[]
-         description = "Time needed to create an inventory list of systems")
+         description = "Time needed to process the inventory")
          // end::desForList[]
   // end::timedForList[]
   // tag::countedForList[]

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryUtils.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryUtils.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ import io.openliberty.guides.inventory.client.UnknownUrlExceptionMapper;
 
 public class InventoryUtils {
 
-  private final String DEFAULT_PORT = System.getProperty("default.http.port");
+  private final String DEFAULT_PORT = System.getProperty("default.http.port", "9080");
 
   // tag::builder[]
   public Properties getProperties(String hostname) {

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -5,14 +5,19 @@
     <feature>jaxrs-2.1</feature>
     <feature>jsonp-1.1</feature>
     <feature>cdi-2.0</feature>
+    <!-- tag::mpMetrics[] -->
     <feature>mpMetrics-2.0</feature>
+    <!-- end::mpMetrics[] -->
+    <!-- tag::monitor[] -->
+    <feature>monitor-1.0</feature>
+    <!-- end::monitor[] -->
     <feature>mpRestClient-1.3</feature>
   </featureManager>
 
   <applicationManager autoExpand="true" />
   <quickStartSecurity userName="admin" userPassword="adminpwd"/>
   <keyStore id="defaultKeyStore" location="key.jks" type="jks" password="mpKeystore"/>
-  <httpEndpoint host="*" httpPort="${default.http.port}" 
+  <httpEndpoint host="*" httpPort="${default.http.port}"
       httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
   <webApplication location="microprofile-metrics.war" contextRoot="/"/>
 </server>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -13,6 +13,9 @@
     <feature>mpRestClient-1.3</feature>
   </featureManager>
 
+  <variable name="default.http.port" defaultValue="9080"/>
+  <variable name="default.https.port" defaultValue="9443"/>
+
   <applicationManager autoExpand="true" />
   <!-- tag::quickStartSecurity[] -->
   <quickStartSecurity userName="admin" userPassword="adminpwd"/>
@@ -22,5 +25,5 @@
   <!-- end::keyStore[] -->
   <httpEndpoint host="*" httpPort="${default.http.port}"
       httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
-  <webApplication location="microprofile-metrics.war" contextRoot="/"/>
+  <webApplication location="guide-microprofile-metrics.war" contextRoot="/"/>
 </server>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -1,4 +1,3 @@
-<!-- tag::server[] -->
 <server description="Sample Liberty server">
 
   <featureManager>
@@ -15,10 +14,13 @@
   </featureManager>
 
   <applicationManager autoExpand="true" />
+  <!-- tag::quickStartSecurity[] -->
   <quickStartSecurity userName="admin" userPassword="adminpwd"/>
+  <!-- end::quickStartSecurity[] -->
+  <!-- tag::keyStore[] -->
   <keyStore id="defaultKeyStore" location="key.jks" type="jks" password="mpKeystore"/>
+  <!-- end::keyStore[] -->
   <httpEndpoint host="*" httpPort="${default.http.port}"
       httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
   <webApplication location="microprofile-metrics.war" contextRoot="/"/>
 </server>
-<!-- end::server[] -->

--- a/finish/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/finish/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,20 +13,21 @@
 // tag::testClass[]
 package it.io.openliberty.guides.inventory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-public class InventoryEndpointTest {
+public class InventoryEndpointIT {
 
   private static String port;
   private static String baseUrl;
@@ -36,19 +37,19 @@ public class InventoryEndpointTest {
   private final String SYSTEM_PROPERTIES = "system/properties";
   private final String INVENTORY_SYSTEMS = "inventory/systems";
 
-  @BeforeClass
+  @BeforeAll
   public static void oneTimeSetup() {
-    port = System.getProperty("liberty.test.port");
+    port = System.getProperty("http.port");
     baseUrl = "http://localhost:" + port + "/";
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     client = ClientBuilder.newClient();
     client.register(JsrJsonpProvider.class);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     client.close();
   }
@@ -57,28 +58,11 @@ public class InventoryEndpointTest {
   // tag::testSuite[]
   @Test
   public void testSuite() {
-    // this.testEmptyInventory();
     this.testHostRegistration();
     this.testSystemPropertiesMatch();
     this.testUnknownHost();
   }
   // end::testSuite[]
-
-  // tag::testEmptyInventory[]
-  public void testEmptyInventory() {
-    Response response = this.getResponse(baseUrl + INVENTORY_SYSTEMS);
-    this.assertResponse(baseUrl, response);
-
-    JsonObject obj = response.readEntity(JsonObject.class);
-
-    int expected = 0;
-    int actual = obj.getInt("total");
-    assertEquals("The inventory should be empty on application start but it wasn't",
-                 expected, actual);
-
-    response.close();
-  }
-  // end::testEmptyInventory[]
 
   // tag::testHostRegistration[]
   public void testHostRegistration() {
@@ -89,16 +73,19 @@ public class InventoryEndpointTest {
 
     JsonObject obj = response.readEntity(JsonObject.class);
 
-    int expected = 1;
-    int actual = obj.getInt("total");
-    assertEquals("The inventory should have one entry for localhost", expected,
-                 actual);
+    JsonArray systems = obj.getJsonArray("systems");
 
-    boolean localhostExists = obj.getJsonArray("systems").getJsonObject(0)
-                                 .get("hostname").toString()
-                                 .contains("localhost");
-    assertTrue("A host was registered, but it was not localhost",
-               localhostExists);
+    boolean localhostExists = false;
+    for (int n = 0; n < systems.size(); n++) {
+        localhostExists = systems.getJsonObject(n)
+                            .get("hostname").toString()
+                            .contains("localhost");
+        if (localhostExists) {
+          break;
+        }
+    }
+    assertTrue(localhostExists,
+               "A host was registered, but it was not localhost");
 
     response.close();
   }
@@ -145,8 +132,8 @@ public class InventoryEndpointTest {
     String obj = badResponse.readEntity(String.class);
 
     boolean isError = obj.contains("ERROR");
-    assertTrue("badhostname is not a valid host but it didn't raise an error",
-               isError);
+    assertTrue(isError,
+               "badhostname is not a valid host but it didn't raise an error");
 
     response.close();
     badResponse.close();
@@ -183,8 +170,7 @@ public class InventoryEndpointTest {
    */
   // end::javadoc[]
   private void assertResponse(String url, Response response) {
-    assertEquals("Incorrect response code from " + url, 200,
-                 response.getStatus());
+    assertEquals(200, response.getStatus(), "Incorrect response code from " + url);
   }
 
   // tag::javadoc[]
@@ -204,9 +190,9 @@ public class InventoryEndpointTest {
   // end::javadoc[]
   private void assertProperty(String propertyName, String hostname,
       String expected, String actual) {
-    assertEquals("JVM system property [" + propertyName + "] "
+    assertEquals(expected, actual, "JVM system property [" + propertyName + "] "
         + "in the system service does not match the one stored in "
-        + "the inventory service for " + hostname, expected, actual);
+        + "the inventory service for " + hostname);
   }
 
   // tag::javadoc[]

--- a/finish/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/finish/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,6 +1,6 @@
 //tag::comment[]
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corporation and others.
+* Copyright (c) 2017, 2019 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -12,20 +12,20 @@
 // end::comment[]
 package it.io.openliberty.guides.system;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import javax.json.JsonObject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SystemEndpointTest {
+public class SystemEndpointIT {
 
   @Test
   public void testGetProperties() {
-    String port = System.getProperty("liberty.test.port");
+    String port = System.getProperty("http.port");
     String url = "http://localhost:" + port + "/";
 
     Client client = ClientBuilder.newClient();
@@ -34,13 +34,12 @@ public class SystemEndpointTest {
     WebTarget target = client.target(url + "system/properties");
     Response response = target.request().get();
 
-    assertEquals("Incorrect response code from " + url, 200,
-                 response.getStatus());
+    assertEquals(200, response.getStatus(), "Incorrect response code from " + url);
 
     JsonObject obj = response.readEntity(JsonObject.class);
 
-    assertEquals("The system property for the local and remote JVM should match",
-                 System.getProperty("os.name"), obj.getString("os.name"));
+    assertEquals(System.getProperty("os.name"), obj.getString("os.name"),
+                 "The system property for the local and remote JVM should match");
 
     response.close();
   }

--- a/scripts/travisTest.sh
+++ b/scripts/travisTest.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euxo pipefail
+
+##############################################################################
+##
+##  Travis CI test script
+##
+##############################################################################
+
+mvn -q clean package liberty:create liberty:install-feature liberty:deploy
+mvn liberty:start
+mvn failsafe:integration-test liberty:stop
+mvn failsafe:verify

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
       <groupId>net.wasdev.wlp.maven.parent</groupId>
       <artifactId>liberty-maven-app-parent</artifactId>
@@ -60,14 +60,14 @@
         <type>esa</type>
         <scope>provided</scope>
     </dependency>
-    <!-- tag::metrics[] -->
+    <!-- tag::mpMetrics[] -->
     <dependency>
         <groupId>io.openliberty.features</groupId>
         <artifactId>mpMetrics-2.0</artifactId>
         <type>esa</type>
         <scope>provided</scope>
     </dependency>
-    <!-- end::metrics[] -->
+    <!-- end::mpMetrics[] -->
     <dependency>
         <groupId>io.openliberty.features</groupId>
         <artifactId>mpRestClient-1.3</artifactId>
@@ -110,25 +110,25 @@
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>2.3.1</version>
-        <scope>test</scope> 
+        <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-core</artifactId>
         <version>2.3.0.1</version>
-        <scope>test</scope> 
+        <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
         <version>2.3.2</version>
-        <scope>test</scope> 
+        <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>javax.activation</groupId>
         <artifactId>activation</artifactId>
         <version>1.1.1</version>
-        <scope>test</scope> 
+        <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -3,14 +3,8 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-      <groupId>net.wasdev.wlp.maven.parent</groupId>
-      <artifactId>liberty-maven-app-parent</artifactId>
-      <version>RELEASE</version>
-  </parent>
-
   <groupId>io.openliberty.guides</groupId>
-  <artifactId>microprofile-metrics</artifactId>
+  <artifactId>guide-microprofile-metrics</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>war</packaging>
 
@@ -19,66 +13,32 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <app.name>LibertyProject</app.name>
-    <!-- tag::ports[] -->
-    <testServerHttpPort>9080</testServerHttpPort>
-    <testServerHttpsPort>9443</testServerHttpsPort>
-    <!-- end::ports[] -->
-    <package.file>${project.build.directory}/${app.name}.zip</package.file>
-    <packaging.type>usr</packaging.type>
+    <failOnMissingWebXml>false</failOnMissingWebXml>
+    <!-- Plugin versions -->
+    <version.maven-failsafe-plugin>2.22.2</version.maven-failsafe-plugin>
+    <version.maven-war-plugin>3.2.2</version.maven-war-plugin>
+    <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
+    <!-- Liberty configuration -->
+    <liberty.var.default.http.port>9080</liberty.var.default.http.port>
+    <liberty.var.default.https.port>9443</liberty.var.default.https.port>
   </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.openliberty.features</groupId>
-                <artifactId>features-bom</artifactId>
-                <version>RELEASE</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
   <dependencies>
-    <!-- Open Liberty features -->
+    <!-- Provided dependencies -->
     <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>jaxrs-2.1</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
-    </dependency>
-    <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>jsonp-1.1</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
-    </dependency>
-    <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>cdi-2.0</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
-    </dependency>
-    <!-- tag::mpMetrics[] -->
-    <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>mpMetrics-2.0</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
-    </dependency>
-    <!-- end::mpMetrics[] -->
-    <dependency>
-        <groupId>io.openliberty.features</groupId>
-        <artifactId>mpRestClient-1.3</artifactId>
-        <type>esa</type>
-        <scope>provided</scope>
+      <groupId>org.eclipse.microprofile</groupId>
+      <!-- tag::microprofile[] -->
+      <artifactId>microprofile</artifactId>
+      <!-- end::microprofile[] -->
+      <version>3.0</version>
+      <type>pom</type>
+      <scope>provided</scope>
     </dependency>
     <!-- For tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -124,115 +84,38 @@
         <version>2.3.2</version>
         <scope>test</scope>
     </dependency>
-    <dependency>
-        <groupId>javax.activation</groupId>
-        <artifactId>activation</artifactId>
-        <version>1.1.1</version>
-        <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>
+    <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>3.2.2</version>
-        <configuration>
-          <failOnMissingWebXml>false</failOnMissingWebXml>
-          <packagingExcludes>pom.xml</packagingExcludes>
-        </configuration>
+        <version>${version.maven-war-plugin}</version>
       </plugin>
       <!-- Plugin to run unit tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M1</version>
-        <executions>
-          <execution>
-            <phase>test</phase>
-            <id>default-test</id>
-            <configuration>
-              <excludes>
-                <exclude>**/it/**</exclude>
-              </excludes>
-              <reportsDirectory>${project.build.directory}/test-reports/unit</reportsDirectory>
-            </configuration>
-          </execution>
-        </executions>
+        <version>${version.maven-surefire-plugin}</version>
       </plugin>
       <!-- Enable liberty-maven plugin -->
       <plugin>
-        <groupId>net.wasdev.wlp.maven.plugins</groupId>
+        <groupId>io.openliberty.tools</groupId>
         <artifactId>liberty-maven-plugin</artifactId>
-        <configuration>
-          <assemblyArtifact>
-            <groupId>io.openliberty</groupId>
-            <artifactId>openliberty-runtime</artifactId>
-            <version>RELEASE</version>
-            <type>zip</type>
-          </assemblyArtifact>
-          <configFile>src/main/liberty/config/server.xml</configFile>
-          <packageFile>${package.file}</packageFile>
-          <include>${packaging.type}</include>
-          <bootstrapProperties>
-            <default.http.port>${testServerHttpPort}</default.http.port>
-            <default.https.port>${testServerHttpsPort}</default.https.port>
-          </bootstrapProperties>
-        </configuration>
-        <executions>
-          <execution>
-            <id>install-apps</id>
-            <configuration>
-              <looseApplication>true</looseApplication>
-              <stripVersion>true</stripVersion>
-              <installAppPackages>project</installAppPackages>
-            </configuration>
-          </execution>
-          <execution>
-            <id>package-server</id>
-            <configuration>
-              <outputDirectory>target/wlp-package</outputDirectory>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <!-- Plugin to run functional tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M1</version>
-        <executions>
-          <execution>
-            <phase>integration-test</phase>
-            <id>integration-test</id>
-            <goals>
-              <goal>integration-test</goal>
-            </goals>
-            <configuration>
-              <runOrder>reversealphabetical</runOrder>
-              <includes>
-                <include>**/it/**/*.java</include>
-              </includes>
-              <!-- tag::system-props[] -->
-              <systemPropertyVariables>
-                <liberty.test.port>${testServerHttpPort}</liberty.test.port>
-                <liberty.https.port>${testServerHttpsPort}</liberty.https.port>
-                <javax.net.ssl.trustStore>${project.build.directory}/liberty/wlp/usr/servers/defaultServer/resources/security/key.jks</javax.net.ssl.trustStore>
-              </systemPropertyVariables>
-              <!-- end::system-props[] -->
-            </configuration>
-          </execution>
-          <execution>
-            <id>verify-results</id>
-            <goals>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
+        <version>${version.maven-failsafe-plugin}</version>
         <configuration>
-          <summaryFile>${project.build.directory}/test-reports/it/failsafe-summary.xml</summaryFile>
-          <reportsDirectory>${project.build.directory}/test-reports/it</reportsDirectory>
+          <systemPropertyVariables>
+            <http.port>${liberty.var.default.http.port}</http.port>
+            <https.port>${liberty.var.default.https.port}</https.port>
+            <javax.net.ssl.trustStore>${project.build.directory}/liberty/wlp/usr/servers/defaultServer/resources/security/key.jks</javax.net.ssl.trustStore>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/start/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/start/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -1,0 +1,22 @@
+package io.openliberty.guides.inventory;
+
+import java.util.Properties;
+import javax.enterprise.context.ApplicationScoped;
+
+import io.openliberty.guides.inventory.model.InventoryList;
+
+@ApplicationScoped
+public class InventoryManager {
+
+	public Properties get(String hostname) {
+		return null;
+	}
+
+	public void add(String hostname, Properties props) {	
+	}
+
+	public InventoryList list() {
+		return null;
+	}
+	
+}

--- a/start/src/main/java/io/openliberty/guides/inventory/InventoryUtils.java
+++ b/start/src/main/java/io/openliberty/guides/inventory/InventoryUtils.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -25,7 +25,7 @@ import io.openliberty.guides.inventory.client.UnknownUrlExceptionMapper;
 
 public class InventoryUtils {
 
-  private final String DEFAULT_PORT = System.getProperty("default.http.port");
+  private final String DEFAULT_PORT = System.getProperty("default.http.port", "9080");
 
   // tag::builder[]
   public Properties getProperties(String hostname) {

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -1,0 +1,9 @@
+<server description="Sample Liberty server">
+
+  <featureManager>
+    <feature>servlet-4.0</feature>
+  </featureManager>
+
+  <webApplication location="guide-microprofile-metrics.war" contextRoot="/"/>
+  
+</server>

--- a/start/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/start/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,20 +13,21 @@
 // tag::testClass[]
 package it.io.openliberty.guides.inventory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-public class InventoryEndpointTest {
+public class InventoryEndpointIT {
 
   private static String port;
   private static String baseUrl;
@@ -36,19 +37,19 @@ public class InventoryEndpointTest {
   private final String SYSTEM_PROPERTIES = "system/properties";
   private final String INVENTORY_SYSTEMS = "inventory/systems";
 
-  @BeforeClass
+  @BeforeAll
   public static void oneTimeSetup() {
-    port = System.getProperty("liberty.test.port");
+    port = System.getProperty("http.port");
     baseUrl = "http://localhost:" + port + "/";
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     client = ClientBuilder.newClient();
     client.register(JsrJsonpProvider.class);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     client.close();
   }
@@ -57,28 +58,11 @@ public class InventoryEndpointTest {
   // tag::testSuite[]
   @Test
   public void testSuite() {
-    // this.testEmptyInventory();
     this.testHostRegistration();
     this.testSystemPropertiesMatch();
     this.testUnknownHost();
   }
   // end::testSuite[]
-
-  // tag::testEmptyInventory[]
-  public void testEmptyInventory() {
-    Response response = this.getResponse(baseUrl + INVENTORY_SYSTEMS);
-    this.assertResponse(baseUrl, response);
-
-    JsonObject obj = response.readEntity(JsonObject.class);
-
-    int expected = 0;
-    int actual = obj.getInt("total");
-    assertEquals("The inventory should be empty on application start but it wasn't",
-                 expected, actual);
-
-    response.close();
-  }
-  // end::testEmptyInventory[]
 
   // tag::testHostRegistration[]
   public void testHostRegistration() {
@@ -89,16 +73,19 @@ public class InventoryEndpointTest {
 
     JsonObject obj = response.readEntity(JsonObject.class);
 
-    int expected = 1;
-    int actual = obj.getInt("total");
-    assertEquals("The inventory should have one entry for localhost", expected,
-                 actual);
+    JsonArray systems = obj.getJsonArray("systems");
 
-    boolean localhostExists = obj.getJsonArray("systems").getJsonObject(0)
-                                 .get("hostname").toString()
-                                 .contains("localhost");
-    assertTrue("A host was registered, but it was not localhost",
-               localhostExists);
+    boolean localhostExists = false;
+    for (int n = 0; n < systems.size(); n++) {
+        localhostExists = systems.getJsonObject(n)
+                            .get("hostname").toString()
+                            .contains("localhost");
+        if (localhostExists) {
+          break;
+        }
+    }
+    assertTrue(localhostExists,
+               "A host was registered, but it was not localhost");
 
     response.close();
   }
@@ -145,8 +132,8 @@ public class InventoryEndpointTest {
     String obj = badResponse.readEntity(String.class);
 
     boolean isError = obj.contains("ERROR");
-    assertTrue("badhostname is not a valid host but it didn't raise an error",
-               isError);
+    assertTrue(isError,
+               "badhostname is not a valid host but it didn't raise an error");
 
     response.close();
     badResponse.close();
@@ -183,8 +170,7 @@ public class InventoryEndpointTest {
    */
   // end::javadoc[]
   private void assertResponse(String url, Response response) {
-    assertEquals("Incorrect response code from " + url, 200,
-                 response.getStatus());
+    assertEquals(200, response.getStatus(), "Incorrect response code from " + url);
   }
 
   // tag::javadoc[]
@@ -204,9 +190,9 @@ public class InventoryEndpointTest {
   // end::javadoc[]
   private void assertProperty(String propertyName, String hostname,
       String expected, String actual) {
-    assertEquals("JVM system property [" + propertyName + "] "
+    assertEquals(expected, actual, "JVM system property [" + propertyName + "] "
         + "in the system service does not match the one stored in "
-        + "the inventory service for " + hostname, expected, actual);
+        + "the inventory service for " + hostname);
   }
 
   // tag::javadoc[]

--- a/start/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/start/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -1,6 +1,6 @@
 //tag::comment[]
 /*******************************************************************************
-* Copyright (c) 2017 IBM Corporation and others.
+* Copyright (c) 2017, 2019 IBM Corporation and others.
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0
 * which accompanies this distribution, and is available at
@@ -12,20 +12,20 @@
 // end::comment[]
 package it.io.openliberty.guides.system;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import javax.json.JsonObject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import org.apache.cxf.jaxrs.provider.jsrjsonp.JsrJsonpProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SystemEndpointTest {
+public class SystemEndpointIT {
 
   @Test
   public void testGetProperties() {
-    String port = System.getProperty("liberty.test.port");
+    String port = System.getProperty("http.port");
     String url = "http://localhost:" + port + "/";
 
     Client client = ClientBuilder.newClient();
@@ -34,13 +34,12 @@ public class SystemEndpointTest {
     WebTarget target = client.target(url + "system/properties");
     Response response = target.request().get();
 
-    assertEquals("Incorrect response code from " + url, 200,
-                 response.getStatus());
+    assertEquals(200, response.getStatus(), "Incorrect response code from " + url);
 
     JsonObject obj = response.readEntity(JsonObject.class);
 
-    assertEquals("The system property for the local and remote JVM should match",
-                 System.getProperty("os.name"), obj.getString("os.name"));
+    assertEquals(System.getProperty("os.name"), obj.getString("os.name"),
+                 "The system property for the local and remote JVM should match");
 
     response.close();
   }


### PR DESCRIPTION
Update guide to mpMetrics-2.0 according to issues raised in https://github.com/OpenLiberty/guides-common/issues/224, #50. 

Specific changes: 
- Updated metric outputs where the formats are different, ie, `@Gauged`, `@Counted` and some base metric outputs
- Added Liberty vendor metrics
- Updated `@Countered` annotation description to be counting monotonically upwards only
- Added tags for the `@Timed` annotation to demonstrate multi-dimension metrics
- Added description of the multi-dimension metrics with tag and updated guide accordingly
- Updated the `start` directory