### PR TITLE
Revert the change of \\s+ in MetricsIT.java

### DIFF
--- a/finish/src/test/java/it/io/openliberty/guides/metrics/MetricsIT.java
+++ b/finish/src/test/java/it/io/openliberty/guides/metrics/MetricsIT.java
@@ -91,7 +91,7 @@ public class MetricsIT {
     for (String metric : metrics) {
       if (metric.startsWith(
           "application_inventoryProcessingTime_rate_per_second")) {
-        float seconds = Float.parseFloat(metric.split("\\s+")[1]);
+        float seconds = Float.parseFloat(metric.split(" ")[1]);
         assertTrue(4 > seconds);
       }
     }


### PR DESCRIPTION
master and qa sites not support showing `\\s+` yet, so revert the change