### PR TITLE
Add cloud-hosted guide instruction

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2020 IBM Corporation and others.
+// Copyright (c) 2018, 2021 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -61,18 +61,31 @@ include::{common-includes}/gitclone.adoc[]
 [role='command']
 include::{common-includes}/twyb-intro.adoc[]
 
-Point your browser to the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL to access the `inventory`
-service. Because you just started the application, the inventory is currently empty. Access the
-http://localhost:9080/inventory/systems/localhost[http://localhost:9080/inventory/systems/localhost^] URL to add the localhost into the inventory.
+Point your browser to the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL to access the `inventory` service. Because you just started the application, the inventory is currently empty. 
+Access the http://localhost:9080/inventory/systems/localhost[http://localhost:9080/inventory/systems/localhost^] URL to add the localhost into the inventory.
 
-Access the `inventory` service at the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL at least once
-for application metrics to be collected. Otherwise, the metrics will not appear.
+Access the `inventory` service at the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL at least once for application metrics to be collected. Otherwise, the metrics will not appear.
 
+// static guide instructions:
+ifndef::cloud-hosted[]
 Next, point your browser to the https://localhost:9443/metrics[http://localhost:9443/metrics^] MicroProfile Metrics endpoint. Log in
 as the `admin` user with `adminpwd` as the password. You can see both the system and application
 metrics in a text format.
 
 To see only the application metrics, point your browser to https://localhost:9443/metrics/application[https://localhost:9443/metrics/application^].
+endif::[]
+
+// cloud-hosted guide instructions:
+ifdef::cloud-hosted[]
+Next, to visit the **/metrics** MicroProfile Metrics endpoint, select **Launch Application** from the menu of the IDE, 
+type in **9443** to specify the port number for the front-end web application, and click the **OK** button. 
+You’re redirected to the **`https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai`** URL, 
+where **accountname** is your account name. Click the **metrics** link on the welcome page.
+Log in as the **admin** user with **adminpwd** as the password. You can see both the system and application
+metrics in a text format.
+
+To see only the application metrics, visit the **/metrics/application** endpoint by clicking the **application metrics** link on the welcome page.
+endif::[]
 
 See the following sample outputs for the `@Timed`, `@Gauge`, and `@Counted` metrics:
 
@@ -108,7 +121,15 @@ application_inventorySizeGauge 1
 application_inventoryAccessCount_total 1
 ----
 
+// static guide instructions:
+ifndef::cloud-hosted[]
 To see only the system metrics, point your browser to https://localhost:9443/metrics/base[https://localhost:9443/metrics/base^].
+endif::[]
+
+// cloud-hosted guide instructions:
+ifdef::cloud-hosted[]
+To see only the system metrics, visit the **/metrics/base** endpoint by clicking the **system metrics** link on the welcome page.
+endif::[]
 
 See the following sample output:
 
@@ -125,7 +146,15 @@ base_jvm_uptime_seconds 30.342000000000002
 base_classloader_loadedClasses_count 11231
 ----
 
+// static guide instructions:
+ifndef::cloud-hosted[]
 To see only the vendor metrics, point your browser to https://localhost:9443/metrics/vendor[https://localhost:9443/metrics/vendor^].
+endif::[]
+
+// cloud-hosted guide instructions:
+ifdef::cloud-hosted[]
+To see only the vendor metrics, visit the **/metrics/vendor** endpoint by clicking the **vendor metrics** link on the welcome page.
+endif::[]
 
 See the following sample output:
 
@@ -261,6 +290,8 @@ Visit the https://openliberty.io/docs/ref/general/#metrics-list.html[Metrics ref
 
 The Open Liberty server was started in development mode at the beginning of the guide and all the changes were automatically picked up.
 
+// static guide instructions:
+ifndef::cloud-hosted[]
 Point your browser to the https://localhost:9443/metrics[https://localhost:9443/metrics^] URL to review the all available metrics
 that have been enabled through MicroProfile Metrics. Log in with `admin` as your username and
 `adminpwd` as your password. You see only the system and vendor metrics because the server just started,
@@ -271,6 +302,30 @@ https://localhost:9443/metrics[https://localhost:9443/metrics^] URL, or access o
 https://localhost:9443/metrics/application[https://localhost:9443/metrics/application^] URL.
 
 You can see the system metrics in the https://localhost:9443/metrics/base[^] URL as well as see the vendor metrics in the https://localhost:9443/metrics/vendor[^] URL.
+endif::[]
+
+// cloud-hosted guide instructions:
+ifdef::cloud-hosted[]
+Select **Launch Application** from the menu of the IDE, 
+type in **9443** to specify the port number for the front-end web application, and click the **OK** button. 
+You’re redirected to the **`https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai`** URL.
+
+To review the all available metrics that have been enabled through MicroProfile Metrics, click the **metrics** link on the welcome page.
+Log in with **admin** as your username and **adminpwd** as your password. You see only the system and vendor metrics because the server just started,
+and the **inventory** service has not been accessed.
+
+Next, run the following curl command from the terminal in the IDE:
+```
+curl http://localhost:9080/inventory/systems
+```
+{: codeblock}
+
+Reload the **`https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai/metrics`** URL,
+or access only the application metrics by clicking the **application metrics** link on the welcome page.
+
+You can see the system metrics by clicking the **system metrics** link on the welcome page, 
+as well as see the vendor metrics by clicking the **vendor metrics** link on the welcome page.
+endif::[]
 
 
 // =================================================================================================

--- a/README.adoc
+++ b/README.adoc
@@ -79,7 +79,7 @@ endif::[]
 ifdef::cloud-hosted[]
 Next, to visit the **/metrics** MicroProfile Metrics endpoint, select **Launch Application** from the menu of the IDE, 
 type in **9443** to specify the port number for the front-end web application, and click the **OK** button. 
-You’re redirected to the **`https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai`** URL, 
+You’re redirected to the **`https://accountname-9443.theiadocker-4.proxy.cognitiveclass.ai`** URL, 
 where **accountname** is your account name. Click the **metrics** link on the welcome page.
 Log in as the **admin** user with **adminpwd** as the password. You can see both the system and application
 metrics in a text format.
@@ -308,7 +308,7 @@ endif::[]
 ifdef::cloud-hosted[]
 Select **Launch Application** from the menu of the IDE, 
 type in **9443** to specify the port number for the front-end web application, and click the **OK** button. 
-You’re redirected to the **`https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai`** URL.
+You’re redirected to the **`https://accountname-9443.theiadocker-4.proxy.cognitiveclass.ai`** URL.
 
 To review the all available metrics that have been enabled through MicroProfile Metrics, click the **metrics** link on the welcome page.
 Log in with **admin** as your username and **adminpwd** as your password. You see only the system and vendor metrics because the server just started,
@@ -320,7 +320,7 @@ curl http://localhost:9080/inventory/systems
 ```
 {: codeblock}
 
-Reload the **`https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai/metrics`** URL,
+Reload the **`https://accountname-9443.theiadocker-4.proxy.cognitiveclass.ai/metrics`** URL,
 or access only the application metrics by clicking the **application metrics** link on the welcome page.
 
 You can see the system metrics by clicking the **system metrics** link on the welcome page, 

--- a/README.adoc
+++ b/README.adoc
@@ -219,7 +219,19 @@ server.xml
 include::finish/src/main/liberty/config/server.xml[]
 ----
 
+// static guide instructions:
+ifndef::cloud-hosted[]
 Navigate to the `start` directory to begin.
+endif::[]
+
+// cloud-hosted guide instructions:
+ifdef::cloud-hosted[]
+To begin, run the following command to navigate to the **start** directory:
+```
+cd /home/project/guide-microprofile-metrics/start
+```
+{: codeblock}
+endif::[]
 
 include::{common-includes}/devmode-start.adoc[]
 

--- a/README.adoc
+++ b/README.adoc
@@ -61,13 +61,13 @@ include::{common-includes}/gitclone.adoc[]
 [role='command']
 include::{common-includes}/twyb-intro.adoc[]
 
+// static guide instructions:
+ifndef::cloud-hosted[]
 Point your browser to the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL to access the `inventory` service. Because you just started the application, the inventory is currently empty. 
 Access the http://localhost:9080/inventory/systems/localhost[http://localhost:9080/inventory/systems/localhost^] URL to add the localhost into the inventory.
 
 Access the `inventory` service at the http://localhost:9080/inventory/systems[http://localhost:9080/inventory/systems^] URL at least once for application metrics to be collected. Otherwise, the metrics will not appear.
 
-// static guide instructions:
-ifndef::cloud-hosted[]
 Next, point your browser to the https://localhost:9443/metrics[http://localhost:9443/metrics^] MicroProfile Metrics endpoint. Log in
 as the `admin` user with `adminpwd` as the password. You can see both the system and application
 metrics in a text format.
@@ -77,6 +77,22 @@ endif::[]
 
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
+Open another command-line session by selecting **Terminal** > **New Terminal** from the menu of the IDE.
+
+Run the following curl command to access the **inventory** service. Because you just started the application, the inventory is currently empty. 
+```
+curl http://localhost:9080/inventory/systems
+```
+{: codeblock}
+
+Run the following curl command to add the localhost into the inventory.
+```
+curl http://localhost:9080/inventory/systems/localhost
+```
+{: codeblock}
+
+Access the **inventory** service at the http://localhost:9080/inventory/systems URL at least once for application metrics to be collected. Otherwise, the metrics will not appear.
+
 Next, run the following curl command to visit the MicroProfile Metrics endpoint by the **admin** user with **adminpwd** as the password. 
 You can see both the system and application metrics in a text format.
 ```

--- a/README.adoc
+++ b/README.adoc
@@ -77,14 +77,18 @@ endif::[]
 
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
-Next, to visit the **/metrics** MicroProfile Metrics endpoint, select **Launch Application** from the menu of the IDE, 
-type in **9443** to specify the port number for the front-end web application, and click the **OK** button. 
-You’re redirected to the **`https://accountname-9443.theiadocker-4.proxy.cognitiveclass.ai`** URL, 
-where **accountname** is your account name. Click the **metrics** link on the welcome page.
-Log in as the **admin** user with **adminpwd** as the password. You can see both the system and application
-metrics in a text format.
+Next, run the following curl command to visit the MicroProfile Metrics endpoint by the **admin** user with **adminpwd** as the password. 
+You can see both the system and application metrics in a text format.
+```
+curl -k --user admin:adminpwd https://localhost:9443/metrics
+```
+{: codeblock}
 
-To see only the application metrics, visit the **/metrics/application** endpoint by clicking the **application metrics** link on the welcome page.
+To see only the application metrics, run the following curl command:
+```
+curl -k --user admin:adminpwd https://localhost:9443/metrics/application
+```
+{: codeblock}
 endif::[]
 
 See the following sample outputs for the `@Timed`, `@Gauge`, and `@Counted` metrics:
@@ -128,7 +132,11 @@ endif::[]
 
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
-To see only the system metrics, visit the **/metrics/base** endpoint by clicking the **system metrics** link on the welcome page.
+To see only the system metrics, run the following curl command:
+```
+curl -k --user admin:adminpwd https://localhost:9443/metrics/base
+```
+{: codeblock}
 endif::[]
 
 See the following sample output:
@@ -153,7 +161,11 @@ endif::[]
 
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
-To see only the vendor metrics, visit the **/metrics/vendor** endpoint by clicking the **vendor metrics** link on the welcome page.
+To see only the vendor metrics, run the following curl command:
+```
+curl -k --user admin:adminpwd https://localhost:9443/metrics/vendor
+```
+{: codeblock}
 endif::[]
 
 See the following sample output:
@@ -306,25 +318,42 @@ endif::[]
 
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
-Select **Launch Application** from the menu of the IDE, 
-type in **9443** to specify the port number for the front-end web application, and click the **OK** button. 
-You’re redirected to the **`https://accountname-9443.theiadocker-4.proxy.cognitiveclass.ai`** URL.
+Run the following curl command to review the all available metrics that have been enabled through MicroProfile Metrics. 
+You see only the system and vendor metrics because the server just started, and the **inventory** service has not been accessed.
+```
+curl -k --user admin:adminpwd https://localhost:9443/metrics
+```
+{: codeblock}
 
-To review the all available metrics that have been enabled through MicroProfile Metrics, click the **metrics** link on the welcome page.
-Log in with **admin** as your username and **adminpwd** as your password. You see only the system and vendor metrics because the server just started,
-and the **inventory** service has not been accessed.
-
-Next, run the following curl command from the terminal in the IDE:
+Next, run the following curl command to access the **inventory** service:
 ```
 curl http://localhost:9080/inventory/systems
 ```
 {: codeblock}
 
-Reload the **`https://accountname-9443.theiadocker-4.proxy.cognitiveclass.ai/metrics`** URL,
-or access only the application metrics by clicking the **application metrics** link on the welcome page.
+Rerun the following curl command to access the all metrics:
+```
+curl -k --user admin:adminpwd https://localhost:9443/metrics
+```
+{: codeblock}
 
-You can see the system metrics by clicking the **system metrics** link on the welcome page, 
-as well as see the vendor metrics by clicking the **vendor metrics** link on the welcome page.
+or access only the application metrics by running following curl command:
+```
+curl -k --user admin:adminpwd https://localhost:9443/metrics/application
+```
+{: codeblock}
+
+You can see the system metrics by running following curl command:
+```
+curl -k --user admin:adminpwd https://localhost:9443/metrics/base
+```
+{: codeblock}
+
+as well as see the vendor metrics by running following curl command:
+```
+curl -k --user admin:adminpwd https://localhost:9443/metrics/vendor
+```
+{: codeblock}
 endif::[]
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -244,8 +244,8 @@ This annotation has these metadata fields:
 The `@Timed` annotation tracks how frequently the method is invoked and how long it takes for each invocation of the method to complete.
 Both the [hotspot=get]`get()` and [hotspot=list]`list()` methods are annotated with the `@Timed` metric and have the same [hotspot=nameForGet hotspot=nameForList]`inventoryProcessingTime` name. The [hotspot=tagForGet]`method=get` and [hotspot=tagForList]`method=list` tags add a dimension that uniquely identifies the collected metric data from the inventory processing time in getting the system properties.
 
-- The [hotspot=tagForGet]`method=get` tag identifies the [hotspot=nameForGet]`inventoryProcessingTime` metric that measures the elapse time in getting the system properties from calling the `system` service.
-- The [hotspot=tagForList]`method=list` tag identifies the [hotspot=nameForList]`inventoryProcessingTime` metric that measures the elapse time for the `inventory` service to list all of the system properties in the inventory.
+* The [hotspot=tagForGet]`method=get` tag identifies the [hotspot=nameForGet]`inventoryProcessingTime` metric that measures the elapse time in getting the system properties from calling the `system` service.
+* The [hotspot=tagForList]`method=list` tag identifies the [hotspot=nameForList]`inventoryProcessingTime` metric that measures the elapse time for the `inventory` service to list all of the system properties in the inventory.
 
 The tags allow you to query the metrics together or separately based on the functionality of the monitoring tool of your choice. The `inventoryProcessingTime` metrics for example could be queried to display an aggregate time of both tagged metrics or individual times.
 

--- a/finish/src/main/webapp/index.html
+++ b/finish/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2020 IBM Corp.
+  Copyright (c) 2016, 2021 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,7 +17,15 @@
 <body>
     <h1>Welcome to your Open Liberty application</h1>
     <p>Open Liberty is a lightweight open framework for building fast and efficient cloud-native Java microservices. Find out more at <a href="http://openliberty.io/" target="_blank" rel="noopener noreferrer">openliberty.io</a>.</p>
-<div>
+    <p>Use the following links to see different metrics:
+      <ul>
+         <li>all <a href="/metrics" target="_blank" rel="noopener noreferrer">metrics</a></li>
+         <li><a href="/metrics/application" target="_blank" rel="noopener noreferrer">application metrics</a></li>
+         <li><a href="/metrics/base" target="_blank" rel="noopener noreferrer">system metrics</a></li>
+         <li><a href="/metrics/vendor" target="_blank" rel="noopener noreferrer">vendor metrics</a></li>
+      </ul>
+    </p>
+    <div>
     <h2>Eclipse MicroProfile</h2>
     <p>
         The <a href="https://microprofile.io/" target="_blank" rel="noopener noreferrer">Eclipse MicroProfile project</a> is an open community with the aim of optimizing enterprise Java for a microservices architecture. 
@@ -38,6 +46,6 @@
             <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-1.4.html">MicroProfile Rest Client 1.4</a></li>
         </ul>
     </p>
-</div>
+    </div>
 </body>
 </html>

--- a/finish/src/main/webapp/index.html
+++ b/finish/src/main/webapp/index.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <!--
   Copyright (c) 2016, 2021 IBM Corp.
 

--- a/finish/src/main/webapp/index.html
+++ b/finish/src/main/webapp/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   Copyright (c) 2016, 2021 IBM Corp.
 

--- a/finish/src/main/webapp/index.html
+++ b/finish/src/main/webapp/index.html
@@ -1,12 +1,9 @@
 <!--
-  Copyright (c) 2016, 2021 IBM Corp.
-
+  Copyright (c) 2016, 2020 IBM Corp.
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-
      http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,15 +14,7 @@
 <body>
     <h1>Welcome to your Open Liberty application</h1>
     <p>Open Liberty is a lightweight open framework for building fast and efficient cloud-native Java microservices. Find out more at <a href="http://openliberty.io/" target="_blank" rel="noopener noreferrer">openliberty.io</a>.</p>
-    <p>Use the following links to see different metrics:
-      <ul>
-         <li>all <a href="/metrics" target="_blank" rel="noopener noreferrer">metrics</a></li>
-         <li><a href="/metrics/application" target="_blank" rel="noopener noreferrer">application metrics</a></li>
-         <li><a href="/metrics/base" target="_blank" rel="noopener noreferrer">system metrics</a></li>
-         <li><a href="/metrics/vendor" target="_blank" rel="noopener noreferrer">vendor metrics</a></li>
-      </ul>
-    </p>
-    <div>
+<div>
     <h2>Eclipse MicroProfile</h2>
     <p>
         The <a href="https://microprofile.io/" target="_blank" rel="noopener noreferrer">Eclipse MicroProfile project</a> is an open community with the aim of optimizing enterprise Java for a microservices architecture. 
@@ -46,6 +35,6 @@
             <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-1.4.html">MicroProfile Rest Client 1.4</a></li>
         </ul>
     </p>
-    </div>
+</div>
 </body>
 </html>

--- a/start/src/main/webapp/index.html
+++ b/start/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2020 IBM Corp.
+  Copyright (c) 2016, 2021 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,7 +17,15 @@
 <body>
     <h1>Welcome to your Open Liberty application</h1>
     <p>Open Liberty is a lightweight open framework for building fast and efficient cloud-native Java microservices. Find out more at <a href="http://openliberty.io/" target="_blank" rel="noopener noreferrer">openliberty.io</a>.</p>
-<div>
+    <p>Use the following links to see different metrics:
+      <ul>
+         <li>all <a href="/metrics" target="_blank" rel="noopener noreferrer">metrics</a></li>
+         <li><a href="/metrics/application" target="_blank" rel="noopener noreferrer">application metrics</a></li>
+         <li><a href="/metrics/base" target="_blank" rel="noopener noreferrer">system metrics</a></li>
+         <li><a href="/metrics/vendor" target="_blank" rel="noopener noreferrer">vendor metrics</a></li>
+      </ul>
+    </p>
+    <div>
     <h2>Eclipse MicroProfile</h2>
     <p>
         The <a href="https://microprofile.io/" target="_blank" rel="noopener noreferrer">Eclipse MicroProfile project</a> is an open community with the aim of optimizing enterprise Java for a microservices architecture. 
@@ -38,6 +46,6 @@
             <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-1.4.html">MicroProfile Rest Client 1.4</a></li>
         </ul>
     </p>
-</div>
+    </div>
 </body>
 </html>

--- a/start/src/main/webapp/index.html
+++ b/start/src/main/webapp/index.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <!--
   Copyright (c) 2016, 2021 IBM Corp.
 

--- a/start/src/main/webapp/index.html
+++ b/start/src/main/webapp/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
   Copyright (c) 2016, 2021 IBM Corp.
 


### PR DESCRIPTION
Add cloud-hosted guide instruction to access the metrics endpoints