### PR TITLE
Refactoring @SimplyTimed annotation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -266,7 +266,7 @@ The `@Timed` annotation tracks how frequently the method is invoked and how long
 
 The tags allow you to query the metrics together or separately based on the functionality of the monitoring tool of your choice. The `inventoryProcessingTime` metrics for example could be queried to display an aggregate time of both tagged metrics or individual times.
 
-Apply the [hotspot=timedForAdd]`@SimplyTimed` annotation to the [hotspot=add]`add()` method to track how frequently the method is invoked and how long it takes for each invocation of the method to complete. `@SimplyTimed` supports the same fields as `@Timed` in the previous table.
+Apply the [hotspot=timedForAdd]`@Timed` annotation to the [hotspot=add]`add()` method to track how frequently the method is invoked and how long it takes for each invocation of the method to complete.
 
 Apply the [hotspot=countedForList]`@Counted` annotation to the [hotspot=list]`list()` method to count how many times the `\http://localhost:9080/inventory/systems` URL is accessed monotonically, which is counting up sequentially.
 
@@ -375,7 +375,7 @@ include::finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.j
 
 * The [hotspot=testInventorySizeGaugeMetric file=0]`testInventorySizeGaugeMetric()` test case validates the [hotspot=gaugeForGetTotal file=1]`@Gauge` metric. The test case first ensures that the localhost is in the inventory, then looks for the [hotspot=gaugeForGetTotal file=1]`@Gauge` metric and asserts that the inventory size is greater or equal to 1.
 
-* The [hotspot=testPropertiesAddSimplyTimeMetric file=0]`testPropertiesAddSimplyTimeMetric()` test case validates the [hotspot=timedForAdd file=1]`@SimplyTimed` metric. The test case sends a request to the `\http://localhost:9080/inventory/systems/localhost` URL to access the `inventory` service, which adds the `localhost` host to the inventory. Next, the test case makes a connection to the `\https://localhost:9443/metrics/application` URL to retrieve application metrics as plain text. Then, it looks for the [hotspot=timedForAdd file=1]`@SimplyTimed` metric and asserts true if the metric exists.
+* The [hotspot=testPropertiesAddSimplyTimeMetric file=0]`testPropertiesAddSimplyTimeMetric()` test case validates the [hotspot=timedForAdd file=1]`@Timed` metric. The test case sends a request to the `\http://localhost:9080/inventory/systems/localhost` URL to access the `inventory` service, which adds the `localhost` host to the inventory. Next, the test case makes a connection to the `\https://localhost:9443/metrics/application` URL to retrieve application metrics as plain text. Then, it looks for the [hotspot=timedForAdd file=1]`@Timed` metric and asserts true if the metric exists.
 
 The [hotspot=oneTimeSetup file=0]`oneTimeSetup()` method retrieves the port number for the server and builds a base URL string to set up the tests. Apply the [hotspot=BeforeAll file=0]`@BeforeAll` annotation to this method to run it before any of the test cases.
 

--- a/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/InventoryManager.java
@@ -59,7 +59,7 @@ public class InventoryManager {
 
   // tag::timedForAdd[]
   // tag::nameForAdd[]
-  @SimplyTimed(name = "inventoryAddingTime",
+  @TImed(name = "inventoryAddingTime",
   // end::nameForAdd[]
     // tag::absoluteForAdd[]
     absolute = true,


### PR DESCRIPTION
Removed `@SimplyTimed` annotation and added in `@Timed` instead. 

This is due to `@SimplyTimed` annotation being depreciated in MP5.0

resolves #171 